### PR TITLE
Binding des modales pour capter celles issues d’une navigation en ajax

### DIFF
--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -1,9 +1,39 @@
 $(document).ready(function() {
   $(document).on("click", '.modal-skills-opener', function() {
-  //$('.modal-skills-opener').on("click",  function() {
-    console.log("click");
-    var modal = $(this).data("modal-target");
-    console.dir(modal);
-    $(modal).modal("open");
+    var modal_selector = $(this).data("modal-target");
+    openModal(modal_selector);
   });
+
+  $(document).on("click", '.modal-map-opener', function() {
+    var trigger = $(this);
+
+    var modalOptions = {
+      ready: function(modal) {
+        var handler = Gmaps.build('Google');
+
+        handler.buildMap({ internal: { id: trigger.data("map-id") } }, function() {
+          var markers = handler.addMarkers(trigger.data("map-markers"));
+          handler.bounds.extendWith(markers);
+          handler.fitMapToBounds();
+          if (markers.length === 0) {
+            handler.getMap().setZoom(2);
+          } else if (markers.length === 1) {
+            handler.getMap().setZoom(14);
+          }
+        });
+      }
+    };
+
+    var modal_selector = $(this).data("modal-target");
+    openModal(modal_selector, modalOptions);
+  });
+
+
+  var openModal = function(selector, options) {
+    options = options || {};
+
+    var modal = $(selector);
+    modal.modal(options);
+    modal.modal("open");
+  };
 });

--- a/app/views/tribes/_card.html.erb
+++ b/app/views/tribes/_card.html.erb
@@ -12,8 +12,17 @@
       <p class="card-short"><%= tribe.short_desk %></p>
     </div>
     <div class="card-action">
-      <a href="javascript:;" data-modal-target="#modalskills-<%= tribe.id %>" class="cyan-text text-darken-2 modal-skills-opener">SKILLS</a>
-      <a href="#modalmap-<%= tribe.id %>" data-tribe-id="<%= tribe.id %>" class="cyan-text text-darken-2 modal-map-opener">MAP</a>
+      <a
+        href="javascript:;"
+        data-modal-target="<%= "#modalskills-#{tribe.id}" %>"
+        class="cyan-text text-darken-2 modal-skills-opener">SKILLS</a>
+
+      <a
+        href="javascript:;"
+        data-modal-target="<%= "#modalmap-#{tribe.id}" %>"
+        data-map-id="<%= "map-#{tribe.id}" %>"
+        data-map-markers="<%= tribe.coordinates.to_json %>"
+        class="cyan-text text-darken-2 modal-map-opener">MAP</a>
       <%= link_to "SHOW", tribe_path(tribe), class: "cyan-text text-darken-2" %>
       <!-- <a href="#" class="cyan-text text-darken-2">SHOW</a> -->
     </div>
@@ -32,45 +41,17 @@
       <% end %>
     </div>
     <div class="modal-footer">
-      <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat">Close</a>
+      <a href="javascript:;" class="modal-action modal-close waves-effect waves-green btn-flat">Close</a>
     </div>
   </div>
   <!-- Modal Structure map-->
   <div id="modalmap-<%= tribe.id %>" class="modal modal-map" data-tribe-id="<%= tribe.id %>">
     <div class="modal-content">
       <h4>Tribe map</h4>
-      <div id="map-<%= tribe.id %>" style="width: 100%; height: 300px;"></div>
+      <div id="<%= "map-#{tribe.id}" %>" style="width: 100%; height: 300px;"></div>
     </div>
     <div class="modal-footer">
-      <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat">Close</a>
+      <a href="javascript:;" class="modal-action modal-close waves-effect waves-green btn-flat">Close</a>
     </div>
   </div>
 </div>
-
-
-<!-- Map -->
-
-<!-- Map rendering -->
-<% content_for(:after_js) do %>
-  <%= javascript_tag do %>
-  $(document).ready(function(){
-
-    <!-- Code JSscript for huts  -->
-    $('#modalmap-<%= tribe.id %>').modal({
-      ready: function(modal, trigger) {
-        var handler = Gmaps.build('Google');
-        handler.buildMap({ internal: { id: 'map-<%= tribe.id %>' } }, function() {
-          markers = handler.addMarkers(<%= raw tribe.coordinates.to_json %>);
-          handler.bounds.extendWith(markers);
-          handler.fitMapToBounds();
-          if (markers.length == 0) {
-            handler.getMap().setZoom(2);
-          } else if (markers.length == 1) {
-            handler.getMap().setZoom(14);
-          }
-        });
-      },
-    });
-  });
-  <% end %>
-<% end %>


### PR DESCRIPTION
Ceci corrige l'ouverture des modales suite à une navigation en ajax (form de filtre des tribes).

En quelques mots : on a besoin de déporter le binding des modales en dehors des vues et de déclencher manuellement leur ouverture en écoutant les clicks sur les liens correspondants. Ceci permet d'agir sur les fenêtres injectées dans le DOM *après* un chargement en ajax.
Les ids, markers etc… sont passés via des data-attributes.



**Comment intégrer ce commit dans votre code :** la pull request n'est pas sur votre `master` mais sur la branche `debug-modal` créée depuis l'ordi de Fabien depuis une de ses branches de travail dont je ne me rappelle plus le nom. 

Fabien après avoir accepté cette pull-request, depuis ta branche dont j'ai oublié le nom et avec un git status clean, fais :

`git pull origin debug-modal`

Ceci mergera mon commit dans ta branche, tu pourras ensuite continuer ton code comme d'hab. J'espère qu'il n'y aura pas de conflit !

